### PR TITLE
Optional argument to automatically submit and terminate when launching.

### DIFF
--- a/Classes/CNSApp.m
+++ b/Classes/CNSApp.m
@@ -73,6 +73,10 @@
   self.bundleVersionLabel.stringValue = (self.bundleVersion ?: @"invalid");
   self.statusLabel.stringValue = @"";
   [self.window setTitle:[self.fileURL lastPathComponent]];
+  
+  if ([[[NSProcessInfo processInfo] arguments] containsObject:@"autoSubmit"]) {
+    [self uploadButtonWasClicked:nil];
+  }
 }
 
 #pragma mark - NSDocument Methods
@@ -273,6 +277,10 @@
       [NSApp endSheet:self.uploadSheet];
       [self.window performClose:self];
       [self close];
+      
+      if ([[[NSProcessInfo processInfo] arguments] containsObject:@"autoSubmit"]) {
+          [NSApp terminate:nil];
+      }
     });
   }
   


### PR DESCRIPTION
I added an optional command line argument so that HockeyMac will automatically submit an opened archive and then quit. This is useful for immediately uploading a new build from Xcode if you don't want to include release notes.

Example usage:
open -a HockeyApp "${ARCHIVE_PATH}" --args autoSubmit
