### PR TITLE
/usr/bin/xcrun preserves symlinks as symlinks, so /usr/bin/zip invocation of HockeyMac should do the same

### DIFF
--- a/Classes/CNSArchive.m
+++ b/Classes/CNSArchive.m
@@ -122,7 +122,7 @@
   [zip setStandardOutput:aPipe];
   [zip setCurrentDirectoryPath:sourcePath];
   [zip setLaunchPath:@"/usr/bin/zip"];
-  [zip setArguments:[NSArray arrayWithObjects:@"-r", filename, source, nil]];
+  [zip setArguments:[NSArray arrayWithObjects:@"-r", @"-y", filename, source, nil]];
   [zip launch];
   
   NSMutableData *dataOut = [NSMutableData data];


### PR DESCRIPTION
Otherwise .ipa created by HockeyMac won't install on devices (code signing check will fail).
