### PR TITLE
* Added 'token=' command line option to overwrite Hockey API Token

### DIFF
--- a/Classes/CNSApp.h
+++ b/Classes/CNSApp.h
@@ -48,6 +48,8 @@
   NSTextView *releaseNotesField;
   NSWindow *uploadSheet;
   NSWindow *window;
+
+  NSString* apiToken;
 }
 
 @property (assign) IBOutlet NSButton *cancelButton;
@@ -74,6 +76,7 @@
 @property (nonatomic, copy) NSString *bundleIdentifier;
 @property (nonatomic, copy) NSString *bundleShortVersion;
 @property (nonatomic, copy) NSString *bundleVersion;
+@property (nonatomic, copy) NSString* apiToken;
 
 - (IBAction)cancelButtonWasClicked:(id)sender;
 - (IBAction)downloadButtonWasClicked:(id)sender;

--- a/Classes/CNSApp.m
+++ b/Classes/CNSApp.m
@@ -62,6 +62,7 @@
 @synthesize uploadSheet;
 @synthesize window;
 @synthesize appIDsAndNames;
+@synthesize apiToken;
 
 #pragma mark - Initialization Methods
 
@@ -285,7 +286,7 @@
   [body appendData:[[NSString stringWithFormat:@"--%@--\r\n", boundary] dataUsingEncoding:NSUTF8StringEncoding]];
   [request setHTTPBody:body];
   
-  self.connectionHelper = [[[CNSConnectionHelper alloc] initWithRequest:request delegate:self selector:@selector(parseVersionResponse:) identifier:nil] autorelease];
+    self.connectionHelper = [[[CNSConnectionHelper alloc] initWithRequest:request delegate:self selector:@selector(parseVersionResponse:) identifier:nil token:self.apiToken] autorelease];
   [self.progressIndicator setHidden:NO];
   [self.errorLabel setHidden:YES];
   [self.statusLabel setHidden:NO];
@@ -331,7 +332,7 @@
 	[request setHTTPMethod:@"GET"];
 	[request setTimeoutInterval:300];
 	
-	self.connectionHelper = [[[CNSConnectionHelper alloc] initWithRequest:request delegate:self selector:@selector(parseAppListResponse:) identifier:nil] autorelease];
+	self.connectionHelper = [[[CNSConnectionHelper alloc] initWithRequest:request delegate:self selector:@selector(parseAppListResponse:) identifier:nil token:self.apiToken] autorelease];
 }
 
 - (void)readProcessArguments {
@@ -365,6 +366,9 @@
     else if (([argument hasPrefix:@"notes="]) && (!ignoreNotesFile)) {
       [self loadReleaseNotesFile:[[argument componentsSeparatedByString:@"="] lastObject]];
       ignoreNotesFile = YES;
+    }
+    else if ([argument hasPrefix:@"token="]) {
+        self.apiToken = [[argument componentsSeparatedByString:@"="] lastObject];
     }
   }
 }
@@ -523,6 +527,7 @@
   self.uploadSheet = nil;
   self.window = nil;
   self.appIDsAndNames = nil;
+  self.apiToken = nil;
   
   [super dealloc];
 }

--- a/Classes/CNSArchive.m
+++ b/Classes/CNSArchive.m
@@ -192,7 +192,7 @@
   [body appendData:[[NSString stringWithFormat:@"--%@--\r\n", boundary] dataUsingEncoding:NSUTF8StringEncoding]];
   [request setHTTPBody:body];
   
-  self.connectionHelper = [[[CNSConnectionHelper alloc] initWithRequest:request delegate:self selector:@selector(parseVersionResponse:) identifier:nil] autorelease];
+  self.connectionHelper = [[[CNSConnectionHelper alloc] initWithRequest:request delegate:self selector:@selector(parseVersionResponse:) identifier:nil token:self.apiToken] autorelease];
   [self.progressIndicator setHidden:NO];
   [self.errorLabel setHidden:YES];
   [self.statusLabel setHidden:NO];

--- a/Vendor/CNSKit/Classes/Helpers/CNSConnectionHelper.h
+++ b/Vendor/CNSKit/Classes/Helpers/CNSConnectionHelper.h
@@ -33,7 +33,7 @@
 
 @property (assign, readonly) NSInteger statusCode;
 
-- (id)initWithRequest:(NSMutableURLRequest *)request delegate:(id)aDelegate selector:(SEL)aSelector identifier:(NSString *)anIdentifier;
+- (id)initWithRequest:(NSMutableURLRequest *)request delegate:(id)aDelegate selector:(SEL)aSelector identifier:(NSString *)anIdentifier token:(NSString*)token;
 - (void)cancelConnection;
 
 @end

--- a/Vendor/CNSKit/Classes/Helpers/CNSConnectionHelper.m
+++ b/Vendor/CNSKit/Classes/Helpers/CNSConnectionHelper.m
@@ -38,7 +38,7 @@
 #pragma mark -
 #pragma mark Initialization
 
-- (id)initWithRequest:(NSMutableURLRequest *)request delegate:(id)aDelegate selector:(SEL)aSelector identifier:(NSString *)anIdentifier {
+- (id)initWithRequest:(NSMutableURLRequest *)request delegate:(id)aDelegate selector:(SEL)aSelector identifier:(NSString *)anIdentifier token:(NSString*)token {
   if ((self = [super init])) {
     delegate = [aDelegate retain];
     selector = aSelector;
@@ -46,8 +46,10 @@
     data = [[NSMutableData alloc] init];
     identifier = [anIdentifier retain];
     
-		NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    NSString *token	= [defaults valueForKey:CNSUserDefaultsToken];
+    if (token == nil) {
+      NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+      token	= [defaults valueForKey:CNSUserDefaultsToken];
+    }
     [request addValue:token	forHTTPHeaderField:@"X-HockeyAppToken"];
     
     connection = [[NSURLConnection alloc] initWithRequest:request delegate:self];  


### PR DESCRIPTION
Hello,

I'd like to add a command line option that enables us to overwrite Hockey API token. I'm working on bunch of different iOS apps and have to use multiple HockeyApp accounts. This patch added "token=API_TOKEN" argument to command line option so that I can use HockeyMac for multiple HockeyApp accounts.

Thanks,
Kazuho
