### PR TITLE
* Read process command line option before retrieve application name

### DIFF
--- a/Classes/CNSApp.m
+++ b/Classes/CNSApp.m
@@ -68,6 +68,7 @@
 
 - (id)initWithContentsOfURL:(NSURL *)absoluteURL ofType:(NSString *)typeName error:(NSError **)outError {
   if ((self = [super initWithContentsOfURL:absoluteURL ofType:typeName error:outError])) {
+      [self readProcessArguments];
 	  [self fetchAppNames];
   }
   return self;
@@ -91,7 +92,6 @@
   
   [self readNotesType];
   [self readAfterUploadSelection];
-  [self readProcessArguments];
 
   [self.window setTitle:[self.fileURL lastPathComponent]];
 }


### PR DESCRIPTION
Ref: https://github.com/codenauts/HockeyMac/pull/12

My previous patch didn't work with latest develop branch because it retrieve application name list before parsing command line option. This patch should fix this issue.
