### PR TITLE
* Added command line option "setAlpha".

### DIFF
--- a/Classes/CNSApp.h
+++ b/Classes/CNSApp.h
@@ -34,7 +34,7 @@
   NSString *bundleShortVersion;
   NSString *bundleVersion;
   NSMatrix *__unsafe_unretained notesTypeMatrix;
-  NSMutableArray *appIDsAndNames;
+  NSMutableDictionary *appIDsAndNames;
   NSPopUpButton *__unsafe_unretained afterUploadMenu;
   NSPopUpButton *__unsafe_unretained fileTypeMenu;
   NSPopUpButton *__unsafe_unretained releaseTypeMenu;

--- a/Resources/en.lproj/CNSApp.xib
+++ b/Resources/en.lproj/CNSApp.xib
@@ -234,7 +234,7 @@
 												<int key="NSTCFlags">1</int>
 											</object>
 											<object class="NSTextViewSharedData" key="NSSharedData">
-												<int key="NSFlags">12259</int>
+												<int key="NSFlags">67121123</int>
 												<int key="NSTextCheckingTypes">0</int>
 												<nil key="NSMarkedAttributes"/>
 												<object class="NSColor" key="NSBackgroundColor" id="823012706">
@@ -769,17 +769,7 @@ AAMAAAABAAEAAAFTAAMAAAAEAAAFwgAAAAAACAAIAAgACAABAAEAAQABA</bytes>
 								<string key="NSKeyEquivalent"/>
 								<int key="NSPeriodicDelay">400</int>
 								<int key="NSPeriodicInterval">75</int>
-								<object class="NSMenuItem" key="NSMenuItem" id="782288543">
-									<reference key="NSMenu" ref="571101280"/>
-									<string key="NSTitle">Alpha</string>
-									<string key="NSKeyEquiv"/>
-									<int key="NSKeyEquivModMask">1048576</int>
-									<int key="NSMnemonicLoc">2147483647</int>
-									<reference key="NSOnImage" ref="734589765"/>
-									<reference key="NSMixedImage" ref="408554333"/>
-									<string key="NSAction">_popUpItemAction:</string>
-									<reference key="NSTarget" ref="525563209"/>
-								</object>
+								<nil key="NSMenuItem"/>
 								<bool key="NSMenuItemRespectAlignment">YES</bool>
 								<object class="NSMenu" key="NSMenu" id="571101280">
 									<string key="NSTitle">OtherViews</string>
@@ -791,13 +781,22 @@ AAMAAAABAAEAAAFTAAMAAAAEAAAFwgAAAAAACAAIAAgACAABAAEAAQABA</bytes>
 											<string key="NSKeyEquiv"/>
 											<int key="NSKeyEquivModMask">1048576</int>
 											<int key="NSMnemonicLoc">2147483647</int>
-											<int key="NSState">1</int>
 											<reference key="NSOnImage" ref="734589765"/>
 											<reference key="NSMixedImage" ref="408554333"/>
 											<string key="NSAction">_popUpItemAction:</string>
 											<reference key="NSTarget" ref="525563209"/>
 										</object>
-										<reference ref="782288543"/>
+										<object class="NSMenuItem" id="782288543">
+											<reference key="NSMenu" ref="571101280"/>
+											<string key="NSTitle">Alpha</string>
+											<string key="NSKeyEquiv"/>
+											<int key="NSKeyEquivModMask">1048576</int>
+											<int key="NSMnemonicLoc">2147483647</int>
+											<reference key="NSOnImage" ref="734589765"/>
+											<reference key="NSMixedImage" ref="408554333"/>
+											<string key="NSAction">_popUpItemAction:</string>
+											<reference key="NSTarget" ref="525563209"/>
+										</object>
 										<object class="NSMenuItem" id="788984552">
 											<reference key="NSMenu" ref="571101280"/>
 											<string key="NSTitle">Beta</string>
@@ -823,7 +822,7 @@ AAMAAAABAAEAAAFTAAMAAAAEAAAFwgAAAAAACAAIAAgACAABAAEAAQABA</bytes>
 									</object>
 									<reference key="NSMenuFont" ref="665714309"/>
 								</object>
-								<int key="NSSelectedIndex">1</int>
+								<int key="NSSelectedIndex">-1</int>
 								<int key="NSPreferredEdge">1</int>
 								<bool key="NSUsesItemFromMenu">YES</bool>
 								<bool key="NSAltersState">YES</bool>
@@ -972,7 +971,7 @@ AAMAAAABAAEAAAFTAAMAAAAEAAAFwgAAAAAACAAIAAgACAABAAEAAQABA</bytes>
 					<reference key="NSWindow"/>
 					<reference key="NSNextKeyView" ref="45854836"/>
 				</object>
-				<string key="NSScreenRect">{{0, 0}, {1440, 878}}</string>
+				<string key="NSScreenRect">{{0, 0}, {2560, 1578}}</string>
 				<string key="NSMinSize">{500, 372}</string>
 				<string key="NSMaxSize">{10000000000000, 10000000000000}</string>
 				<int key="NSWindowCollectionBehavior">32</int>
@@ -1068,7 +1067,7 @@ AAMAAAABAAEAAAFTAAMAAAAEAAAFwgAAAAAACAAIAAgACAABAAEAAQABA</bytes>
 					<string key="NSFrameSize">{480, 121}</string>
 					<reference key="NSNextKeyView" ref="45347724"/>
 				</object>
-				<string key="NSScreenRect">{{0, 0}, {1440, 878}}</string>
+				<string key="NSScreenRect">{{0, 0}, {2560, 1578}}</string>
 				<string key="NSMaxSize">{10000000000000, 10000000000000}</string>
 				<bool key="NSWindowIsRestorable">YES</bool>
 			</object>


### PR DESCRIPTION
I found several issues on HockeyMac HEAD. Here's my patches and changes.
- Fixed an issue that "setBeta" and "setLive" command line option didn't work.
- Fixed an issue that HockeyApp can't handle public ID correctly if a user has multiple release type(alpha/beta/live) under the same app name.
- Fixed my patch cc0d6114bdfc64904c4c97a3e3d86b437e271349. Command line option has to be parsed at before and after window open. (Some arguments has to be set after window is opened.)
- release type drop down menu should be checked by code, not by xib file.

I'm not sure How I handle alpha release_type in POST parameters.(CNSApp.m:286)  So I left it as is, but this has to be set appropriately as well.
