### PR TITLE
Fixed the autoSubmit

### DIFF
--- a/Classes/CNSApp.m
+++ b/Classes/CNSApp.m
@@ -119,7 +119,7 @@ static NSString *CNSExistingVersionSheet = @"CNSExistingVersionSheet";
 
   [self setupViews];
   
-  if (autoSubmit && !(self.publicIdentifier)) { // Can't upload right now if publicIdentifier is set, need to fetch apps first
+  if (autoSubmit && self.publicIdentifier) { // Can't upload right now if publicIdentifier is not set, need to fetch apps first
     [self uploadButtonWasClicked:nil];
   }
 }
@@ -298,7 +298,9 @@ static NSString *CNSExistingVersionSheet = @"CNSExistingVersionSheet";
 - (void)preUploadCheck {
   if ([self doesReleaseTypeMatch]) {
     if (self.bundleIdentifier) {
-      self.publicIdentifier = [self publicIdentifierForSelectedApp];
+      if (self.publicIdentifier == nil) {
+        self.publicIdentifier = [self publicIdentifierForSelectedApp];
+      }
       if (self.publicIdentifier) {
         if (self.ignoreExistingVersion) {
           [self startUploadWithPublicIdentifier:self.publicIdentifier];


### PR DESCRIPTION
I found that the autoSubmit option was broken. When not specifying a publicIdentifier, the application would get 422 errors, but when specifying one, it didn’t auto submit.

My command line invocation was (like) this:
open -a HockeyApp "${ARCHIVE_PATH}" --args onlyDSYM autoSubmit identifier=1234567890abcdef token=1234567890abcdef
